### PR TITLE
Revamp cache implementation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,3 +15,4 @@ lazy val documentation = project
 
 lazy val dummy = module
   .settings(libraryDependencies += "org.scalameta" %% "munit" % "0.7.29" % Test)
+  .settings(libraryDependencies += "org.scala-lang.modules" %% "scala-collection-compat" % "2.9.0")

--- a/build.sbt
+++ b/build.sbt
@@ -14,3 +14,4 @@ lazy val documentation = project
   .settings(mdocOut := file("."))
 
 lazy val dummy = module
+  .settings(libraryDependencies += "org.scalameta" %% "munit" % "0.7.29" % Test)

--- a/docs/README.md
+++ b/docs/README.md
@@ -53,6 +53,17 @@ dummy.cats.garfield
 dummy.cats.sylvester
 ```
 
+### Accessing the cache
+
+You can access the internal `Dummy` cache to see the values in
+store.
+
+```scala mdoc
+dummy.dogs.cache.all
+
+dummy.cats.cache.all
+```
+
 ## Contributors to this project 
 
 @CONTRIBUTORS_TABLE@

--- a/modules/dummy/src/main/scala/com/alejandrohdezma/dummy/Cache.scala
+++ b/modules/dummy/src/main/scala/com/alejandrohdezma/dummy/Cache.scala
@@ -2,11 +2,16 @@ package com.alejandrohdezma.dummy
 
 import java.util.concurrent.ConcurrentHashMap
 
+import scala.jdk.CollectionConverters._
+
 /** Cache for a `Dummy` or `Dummy.WithName` value. */
 trait Cache[A] {
 
   /** Gets the value for key `name` from the cache or creates one using the provided `creator`. */
   def getOrSet(name: String, creator: String => A): A
+
+  /** Returns all values stored in the cache */
+  def all: Map[String, A]
 
 }
 
@@ -17,6 +22,8 @@ object Cache {
     private val internal = new ConcurrentHashMap[String, A]
 
     override def getOrSet(name: String, creator: String => A): A = internal.computeIfAbsent(name, creator(_))
+
+    override def all: Map[String, A] = internal.asScala.toMap
 
   }
 

--- a/modules/dummy/src/main/scala/com/alejandrohdezma/dummy/Cache.scala
+++ b/modules/dummy/src/main/scala/com/alejandrohdezma/dummy/Cache.scala
@@ -1,0 +1,23 @@
+package com.alejandrohdezma.dummy
+
+import java.util.concurrent.ConcurrentHashMap
+
+/** Cache for a `Dummy` or `Dummy.WithName` value. */
+trait Cache[A] {
+
+  /** Gets the value for key `name` from the cache or creates one using the provided `creator`. */
+  def getOrSet(name: String, creator: String => A): A
+
+}
+
+object Cache {
+
+  def fromConcurrentHashMap[A]: Cache[A] = new Cache[A] {
+
+    private val internal = new ConcurrentHashMap[String, A]
+
+    override def getOrSet(name: String, creator: String => A): A = internal.computeIfAbsent(name, creator(_))
+
+  }
+
+}

--- a/modules/dummy/src/main/scala/com/alejandrohdezma/dummy/Dummy.scala
+++ b/modules/dummy/src/main/scala/com/alejandrohdezma/dummy/Dummy.scala
@@ -57,7 +57,7 @@ import scala.language.dynamics
   */
 class Dummy[A](creator: => A) extends Dynamic {
 
-  private val cache: ConcurrentHashMap[String, A] = new ConcurrentHashMap[String, A]
+  val cache: ConcurrentHashMap[String, A] = new ConcurrentHashMap[String, A]
 
   def selectDynamic(name: String): A = cache.computeIfAbsent(name, _ => creator)
 
@@ -102,7 +102,7 @@ object Dummy {
     */
   class WithName[A](creator: String => A) extends Dynamic {
 
-    private val cache: ConcurrentHashMap[String, A] = new ConcurrentHashMap[String, A]
+    val cache: ConcurrentHashMap[String, A] = new ConcurrentHashMap[String, A]
 
     def selectDynamic(name: String): A = cache.computeIfAbsent(name, creator(_))
 

--- a/modules/dummy/src/main/scala/com/alejandrohdezma/dummy/Dummy.scala
+++ b/modules/dummy/src/main/scala/com/alejandrohdezma/dummy/Dummy.scala
@@ -16,8 +16,6 @@
 
 package com.alejandrohdezma.dummy
 
-import java.util.concurrent.ConcurrentHashMap
-
 import scala.language.dynamics
 
 /** Utility for creating dummy data for tests.
@@ -57,9 +55,10 @@ import scala.language.dynamics
   */
 class Dummy[A](creator: => A) extends Dynamic {
 
-  val cache: ConcurrentHashMap[String, A] = new ConcurrentHashMap[String, A]
+  /** The cache containing all the values created by this dummy object. */
+  val cache: Cache[A] = Cache.fromConcurrentHashMap[A]
 
-  def selectDynamic(name: String): A = cache.computeIfAbsent(name, _ => creator)
+  def selectDynamic(name: String): A = cache.getOrSet(name, _ => creator)
 
 }
 
@@ -102,9 +101,10 @@ object Dummy {
     */
   class WithName[A](creator: String => A) extends Dynamic {
 
-    val cache: ConcurrentHashMap[String, A] = new ConcurrentHashMap[String, A]
+    /** The cache containing all the values created by this dummy object. */
+    val cache: Cache[A] = Cache.fromConcurrentHashMap[A]
 
-    def selectDynamic(name: String): A = cache.computeIfAbsent(name, creator(_))
+    def selectDynamic(name: String): A = cache.getOrSet(name, creator)
 
   }
 

--- a/modules/dummy/src/test/scala/com/alejandrohdezma/dummy/CacheSuite.scala
+++ b/modules/dummy/src/test/scala/com/alejandrohdezma/dummy/CacheSuite.scala
@@ -1,0 +1,27 @@
+package com.alejandrohdezma.dummy
+
+import java.util.UUID
+
+import munit.FunSuite
+
+class CacheSuite extends FunSuite {
+
+  test("Cache.fromConcurrentHashMap creates a valid cache") {
+    val cache = Cache.fromConcurrentHashMap[String]
+
+    val a = List
+      .fill(10)(cache.getOrSet("a", key => s"$key-${UUID.randomUUID()}"))
+      .distinct
+
+    val b = List
+      .fill(10)(cache.getOrSet("b", key => s"$key-${UUID.randomUUID()}"))
+      .distinct
+
+    assertEquals(a.size, 1)
+    assert(a.head.startsWith("a-"))
+
+    assertEquals(b.size, 1)
+    assert(b.head.startsWith("b-"))
+  }
+
+}

--- a/modules/dummy/src/test/scala/com/alejandrohdezma/dummy/CacheSuite.scala
+++ b/modules/dummy/src/test/scala/com/alejandrohdezma/dummy/CacheSuite.scala
@@ -24,4 +24,20 @@ class CacheSuite extends FunSuite {
     assert(b.head.startsWith("b-"))
   }
 
+  test("Cache.all returns all values stored in the cache") {
+    val cache = Cache.fromConcurrentHashMap[String]
+
+    val a = List
+      .fill(10)(cache.getOrSet("a", key => s"$key-${UUID.randomUUID()}"))
+      .distinct
+
+    val b = List
+      .fill(10)(cache.getOrSet("b", key => s"$key-${UUID.randomUUID()}"))
+      .distinct
+
+    val expected = Map("a" -> a.head, "b" -> b.head)
+
+    assertEquals(cache.all, expected)
+  }
+
 }

--- a/modules/dummy/src/test/scala/com/alejandrohdezma/dummy/DummySuite.scala
+++ b/modules/dummy/src/test/scala/com/alejandrohdezma/dummy/DummySuite.scala
@@ -1,0 +1,37 @@
+package com.alejandrohdezma.dummy
+
+import java.util.UUID
+
+import munit.FunSuite
+
+class DummySuite extends FunSuite {
+
+  test("Dummy always return the same value from the same key") {
+    val dummy = new Dummy(s"${UUID.randomUUID()}")
+
+    val a = List.fill(10)(dummy.a).distinct
+
+    val b = List.fill(10)(dummy.b).distinct
+
+    assertEquals(a.size, 1)
+    assertEquals(s"${UUID.fromString(a.head)}", a.head)
+
+    assertEquals(b.size, 1)
+    assertEquals(s"${UUID.fromString(b.head)}", b.head)
+  }
+
+  test("Dummy.WithName always return the same value from the same key") {
+    val dummy = new Dummy.WithName(key => s"$key-${UUID.randomUUID()}")
+
+    val a = List.fill(10)(dummy.a).distinct
+
+    val b = List.fill(10)(dummy.b).distinct
+
+    assertEquals(a.size, 1)
+    assertEquals(s"a-${UUID.fromString(a.head.drop(2))}", a.head)
+
+    assertEquals(b.size, 1)
+    assertEquals(s"b-${UUID.fromString(b.head.drop(2))}", b.head)
+  }
+
+}


### PR DESCRIPTION
This PR enables accessing the internal cache of a dummy object.

It also extracts the cache implementation from being directly a `ConcurrentHashMap` to its own type `Cache`, with dedicated methods for accessing it.