### PR TITLE
Add `Dummy.fromNaturalLanguageDate` to allow creating `Instant` values easily

### DIFF
--- a/.github/docs/README.md
+++ b/.github/docs/README.md
@@ -23,6 +23,8 @@ object dummy {
 
   val cats = Dummy.withName(name => s"${Random.alphanumeric.take(5).mkString}-$name")
 
+  val dates = Dummy.fromNaturalLanguageDate()
+
 }
 ```
 
@@ -38,6 +40,10 @@ dummy.dogs.`santa's-little-helper`
 dummy.cats.garfield
 
 dummy.cats.sylvester
+
+dummy.dates.`3 days ago`
+
+dummy.dates.yesterday
 ```
 
 The key of these generators is that values are cached, so if we try to use the
@@ -51,6 +57,10 @@ dummy.dogs.`santa's-little-helper`
 dummy.cats.garfield
 
 dummy.cats.sylvester
+
+dummy.dates.`3 days ago`
+
+dummy.dates.yesterday
 ```
 
 ### Accessing the cache
@@ -62,6 +72,8 @@ store.
 dummy.dogs.cache.all
 
 dummy.cats.cache.all
+
+dummy.dates.cache.all
 ```
 
 ## Contributors to this project 

--- a/build.sbt
+++ b/build.sbt
@@ -14,5 +14,6 @@ lazy val documentation = project
   .settings(mdocOut := file("."))
 
 lazy val dummy = module
+  .settings(libraryDependencies += "org.ocpsoft.prettytime" % "prettytime-nlp" % "5.0.6.Final")
   .settings(libraryDependencies += "org.scalameta" %% "munit" % "0.7.29" % Test)
   .settings(libraryDependencies += "org.scala-lang.modules" %% "scala-collection-compat" % "2.9.0")

--- a/modules/dummy/src/main/scala/com/alejandrohdezma/dummy/Dummy.scala
+++ b/modules/dummy/src/main/scala/com/alejandrohdezma/dummy/Dummy.scala
@@ -16,7 +16,11 @@
 
 package com.alejandrohdezma.dummy
 
+import java.time.Instant
+
 import scala.language.dynamics
+
+import org.ocpsoft.prettytime.nlp.PrettyTimeParser
 
 /** Utility for creating dummy data for tests.
   *
@@ -134,6 +138,43 @@ object Dummy {
     *   }}}
     */
   def withName[A](creator: String => A): Dummy.WithName[A] = new Dummy.WithName[A](creator)
+
+  /** Creates a "dummy" object that allows generating dummy instant values from natural language for tests easily.
+    *
+    * @example
+    *   {{{
+    *   ```scala
+    *   import com.alejandrohdezma.dummy.Dummy
+    *
+    *   object dummy {
+    *
+    *     val dates = Dummy.fromNaturalLanguageDate()
+    *
+    *   }
+    *   ```
+    *
+    *   And then use it in your tests with any value you want:
+    *
+    *   ```scala
+    *   dummy.dates.`5 days ago`
+    *
+    *   dummy.dates.`yesterday`
+    *
+    *   dummy.dates.`last year`
+    *
+    *   dummy.dates.`next tuesday`
+    *   ```
+    *   }}}
+    */
+  def fromNaturalLanguageDate(): Dummy.WithName[Instant] = withName[Instant] { text =>
+    val date = new PrettyTimeParser().parse(text)
+
+    if (date.isEmpty()) {
+      sys.error(s"Unable to parse `$text` as a date")
+    }
+
+    date.get(0).toInstant()
+  }
 
   /** Utility for creating dummy data for tests.
     *

--- a/modules/dummy/src/test/scala/com/alejandrohdezma/dummy/DummySuite.scala
+++ b/modules/dummy/src/test/scala/com/alejandrohdezma/dummy/DummySuite.scala
@@ -16,6 +16,11 @@
 
 package com.alejandrohdezma.dummy
 
+import java.time.DayOfWeek.TUESDAY
+import java.time.Instant
+import java.time.ZonedDateTime
+import java.time.temporal.ChronoUnit._
+import java.time.temporal.TemporalAdjusters.next
 import java.util.UUID
 
 import munit.FunSuite
@@ -48,6 +53,28 @@ class DummySuite extends FunSuite {
 
     assertEquals(b.size, 1)
     assertEquals(s"b-${UUID.fromString(b.head.drop(2))}", b.head)
+  }
+
+  test("Dummy.fromNaturalLanguageDate allows creating dummy values from natural language") {
+    val dummy = Dummy.fromNaturalLanguageDate()
+
+    def assertInstant(obtained: Instant, expected: Instant) =
+      assertEquals(obtained.truncatedTo(DAYS), expected.truncatedTo(DAYS))
+
+    val now = Instant.now()
+
+    assertInstant(dummy.`5 days ago`, now.minus(5, DAYS))
+    assertInstant(dummy.`yesterday`, now.minus(1, DAYS))
+    assertInstant(dummy.`last year`, ZonedDateTime.now().minusYears(1).toInstant)
+    assertInstant(dummy.`next tuesday`, ZonedDateTime.now().`with`(next(TUESDAY)).toInstant())
+  }
+
+  test("Dummy.fromNaturalLanguageDate fails if provided expression is not correct") {
+    val dummy = Dummy.fromNaturalLanguageDate()
+
+    interceptMessage[RuntimeException]("Unable to parse `this is not valid` as a date") {
+      dummy.`this is not valid`
+    }
   }
 
 }


### PR DESCRIPTION
This new constructor creates a "dummy" object that allows generating dummy instant values from natural language for tests easily.

   ```scala
   import com.alejandrohdezma.dummy.Dummy

   object dummy {

     val dates = Dummy.fromNaturalLanguageDate()

   }
   ```

   And then use it in your tests with any value you want:

   ```scala
   dummy.dates.`5 days ago`

   dummy.dates.`yesterday`

   dummy.dates.`last year`

   dummy.dates.`next tuesday`
   ```