### PR TITLE
Allow accessing dummy value using `apply`

### DIFF
--- a/modules/dummy/src/main/scala/com/alejandrohdezma/dummy/Dummy.scala
+++ b/modules/dummy/src/main/scala/com/alejandrohdezma/dummy/Dummy.scala
@@ -64,6 +64,8 @@ class Dummy[A](creator: => A) extends Dynamic {
 
   def selectDynamic(name: String): A = cache.getOrSet(name, _ => creator)
 
+  def apply(name: String): A = selectDynamic(name)
+
 }
 
 object Dummy {
@@ -217,6 +219,8 @@ object Dummy {
     val cache: Cache[A] = Cache.fromConcurrentHashMap[A]
 
     def selectDynamic(name: String): A = cache.getOrSet(name, creator)
+
+    def apply(name: String): A = selectDynamic(name)
 
   }
 

--- a/modules/dummy/src/test/scala/com/alejandrohdezma/dummy/DummySuite.scala
+++ b/modules/dummy/src/test/scala/com/alejandrohdezma/dummy/DummySuite.scala
@@ -36,9 +36,11 @@ class DummySuite extends FunSuite {
 
     assertEquals(a.size, 1)
     assertEquals(s"${UUID.fromString(a.head)}", a.head)
+    assertEquals(dummy("a"), a.head)
 
     assertEquals(b.size, 1)
     assertEquals(s"${UUID.fromString(b.head)}", b.head)
+    assertEquals(dummy("b"), b.head)
   }
 
   test("Dummy.WithName always return the same value from the same key") {
@@ -50,9 +52,11 @@ class DummySuite extends FunSuite {
 
     assertEquals(a.size, 1)
     assertEquals(s"a-${UUID.fromString(a.head.drop(2))}", a.head)
+    assertEquals(dummy("a"), a.head)
 
     assertEquals(b.size, 1)
     assertEquals(s"b-${UUID.fromString(b.head.drop(2))}", b.head)
+    assertEquals(dummy("b"), b.head)
   }
 
   test("Dummy.fromNaturalLanguageDate allows creating dummy values from natural language") {
@@ -64,9 +68,13 @@ class DummySuite extends FunSuite {
     val now = Instant.now()
 
     assertInstant(dummy.`5 days ago`, now.minus(5, DAYS))
+    assertInstant(dummy("5 days ago"), now.minus(5, DAYS))
     assertInstant(dummy.`yesterday`, now.minus(1, DAYS))
+    assertInstant(dummy("yesterday"), now.minus(1, DAYS))
     assertInstant(dummy.`last year`, ZonedDateTime.now().minusYears(1).toInstant)
+    assertInstant(dummy("last year"), ZonedDateTime.now().minusYears(1).toInstant)
     assertInstant(dummy.`next tuesday`, ZonedDateTime.now().`with`(next(TUESDAY)).toInstant())
+    assertInstant(dummy("next tuesday"), ZonedDateTime.now().`with`(next(TUESDAY)).toInstant())
   }
 
   test("Dummy.fromNaturalLanguageDate fails if provided expression is not correct") {


### PR DESCRIPTION
This PR makes this two calls equivalent:

```scala
val dummy = Dummy(UUID.randomUUID())

dummy.test == dummy("test")
```