### PR TITLE
No dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,5 +12,4 @@ lazy val documentation = project
   .dependsOn(dummy)
 
 lazy val dummy = module
-  .settings(libraryDependencies += "org.ocpsoft.prettytime" % "prettytime-nlp" % "5.0.7.Final")
   .settings(libraryDependencies += "org.scalameta" %% "munit" % "0.7.29" % Test)

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 val Scala3 = "3.1.3" // scala-steward:off
 ThisBuild / scalaVersion       := "2.13.12"
-ThisBuild / crossScalaVersions := Seq("2.12.18", "2.13.12", Scala3)
+ThisBuild / crossScalaVersions := Seq("2.13.12", Scala3)
 ThisBuild / organization       := "com.alejandrohdezma"
 
 addCommandAlias("ci-test", "fix --check; mdoc; publishLocal; +test")
@@ -14,4 +14,3 @@ lazy val documentation = project
 lazy val dummy = module
   .settings(libraryDependencies += "org.ocpsoft.prettytime" % "prettytime-nlp" % "5.0.7.Final")
   .settings(libraryDependencies += "org.scalameta" %% "munit" % "0.7.29" % Test)
-  .settings(libraryDependencies += "org.scala-lang.modules" %% "scala-collection-compat" % "2.11.0")

--- a/modules/dummy/src/test/scala/com/alejandrohdezma/dummy/DummySuite.scala
+++ b/modules/dummy/src/test/scala/com/alejandrohdezma/dummy/DummySuite.scala
@@ -108,7 +108,7 @@ class DummySuite extends FunSuite {
   test("Dummy.fromNaturalLanguageDate fails if provided expression is not correct") {
     val dummy = Dummy.fromNaturalLanguageDate()
 
-    interceptMessage[RuntimeException]("Unable to parse `this is not valid` as a date") {
+    interceptMessage[Dummy.IllegalDateException]("Unable to convert `this is not valid` to a valid instant") {
       dummy.`this is not valid`
     }
   }


### PR DESCRIPTION
Removes all dependencies from this library by dropping support for Scala 2.12 and dropping `prettytime-nlp` dependency and providing a simple in-house natural-language processor instead.